### PR TITLE
Non-essential improvements

### DIFF
--- a/MenuTest.xcodeproj/project.pbxproj
+++ b/MenuTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		523657D221E077BB00631186 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 523657D121E077BB00631186 /* MapKit.framework */; };
 		DB1ED22421DE148A00AEB658 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1ED22321DE148A00AEB658 /* AppDelegate.swift */; };
 		DB1ED22621DE148A00AEB658 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1ED22521DE148A00AEB658 /* ViewController.swift */; };
 		DB1ED22921DE148A00AEB658 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DB1ED22721DE148A00AEB658 /* Main.storyboard */; };
@@ -23,6 +24,7 @@
 
 /* Begin PBXFileReference section */
 		22C6FCB6E8258A01047A1F14 /* Pods_MenuTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MenuTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		523657D121E077BB00631186 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		9A077B6042A00FA4D7B76BF7 /* Pods-MenuTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MenuTest.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MenuTest/Pods-MenuTest.debug.xcconfig"; sourceTree = "<group>"; };
 		BFDAE20353D78774FED05BD7 /* Pods-MenuTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MenuTest.release.xcconfig"; path = "Pods/Target Support Files/Pods-MenuTest/Pods-MenuTest.release.xcconfig"; sourceTree = "<group>"; };
 		DB1ED22021DE148A00AEB658 /* MenuTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MenuTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -45,6 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				523657D221E077BB00631186 /* MapKit.framework in Frameworks */,
 				E68567C1D9AD4571E3F3DDF3 /* Pods_MenuTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -64,6 +67,7 @@
 		73D000595D809CE8933B575C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				523657D121E077BB00631186 /* MapKit.framework */,
 				22C6FCB6E8258A01047A1F14 /* Pods_MenuTest.framework */,
 			);
 			name = Frameworks;
@@ -156,6 +160,11 @@
 				TargetAttributes = {
 					DB1ED21F21DE148A00AEB658 = {
 						CreatedOnToolsVersion = 10.1;
+						SystemCapabilities = {
+							com.apple.Maps.iOS = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};

--- a/MenuTest/Base.lproj/Main.storyboard
+++ b/MenuTest/Base.lproj/Main.storyboard
@@ -24,10 +24,10 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="azS-7J-leM" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="13W-KI-q3e"/>
-                            <constraint firstItem="azS-7J-leM" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="8AU-Wa-K0c"/>
+                            <constraint firstItem="azS-7J-leM" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="13W-KI-q3e"/>
+                            <constraint firstItem="azS-7J-leM" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailing" id="8AU-Wa-K0c"/>
                             <constraint firstItem="azS-7J-leM" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="THf-ue-qUd"/>
-                            <constraint firstItem="azS-7J-leM" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="jb8-hh-2Wl"/>
+                            <constraint firstItem="azS-7J-leM" firstAttribute="bottom" secondItem="8bC-Xf-vdC" secondAttribute="bottom" id="jb8-hh-2Wl"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>

--- a/MenuTest/Menu/MenuContents.swift
+++ b/MenuTest/Menu/MenuContents.swift
@@ -309,7 +309,7 @@ class MenuContents: UIView {
         
         let insetAdjustment = scrollView.contentInset.top + scrollView.contentInset.bottom
         
-        scrollContainer.snp.makeConstraints {
+        scrollContainer.snp.remakeConstraints {
             make in
             make.left.bottom.right.equalToSuperview()
             make.top.equalTo(superview.snp.bottom)

--- a/MenuTest/Menu/MenuContents.swift
+++ b/MenuTest/Menu/MenuContents.swift
@@ -139,7 +139,7 @@ class MenuContents: UIView {
         }
     }
     
-    func selectPosition(_ point: CGPoint, completion: @escaping (MenuItem) -> ()) {
+    func selectPosition(_ point: CGPoint, completion: @escaping (MenuItem) -> Void) {
         menuItemViews.enumerated().forEach {
             index, view in
             

--- a/MenuTest/Menu/MenuContents.swift
+++ b/MenuTest/Menu/MenuContents.swift
@@ -78,18 +78,18 @@ class MenuContents: UIView {
     }
     
     private func pointIsInsideBottomEdgeScrollingBoundary(_ point: CGPoint) -> Bool {
-        return point.y > self.scrollView.bounds.size.height - 24 && self.isScrollable
+        return point.y > scrollView.bounds.size.height - 24 && isScrollable
     }
     
     private func pointIsInsideTopEdgeScrollingBoundary(_ point: CGPoint) -> Bool {
-        return point.y < self.scrollView.frame.minY + 40 && self.isScrollable
+        return point.y < scrollView.frame.minY + 40 && isScrollable
     }
     
     private func updateHighlightedPosition(_ point: CGPoint) {
         menuItemViews.forEach {
             var view = $0
             
-            let point = self.convert(point, to: $0)
+            let point = convert(point, to: $0)
             let contains = $0.point(inside: point, with: nil)
             
             view.highlighted = contains
@@ -143,10 +143,13 @@ class MenuContents: UIView {
         menuItemViews.enumerated().forEach {
             index, view in
             
-            let point = self.convert(point, to: view)
+            let point = convert(point, to: view)
             if view.point(inside: point, with: nil) {
                 view.startSelectionAnimation {
-                    completion(self.items[index])
+                    [weak self] in
+                    if let self = self {
+                        completion(self.items[index])
+                    }
                 }
             }
         }

--- a/MenuTest/Menu/MenuItem.swift
+++ b/MenuTest/Menu/MenuItem.swift
@@ -35,19 +35,19 @@ public extension UIKeyModifierFlags {
     public var symbols: [String] {
         var result: [String] = []
         
-        if self.contains(.alternate) {
+        if contains(.alternate) {
             result.append("⌥")
         }
         
-        if self.contains(.control) {
+        if contains(.control) {
             result.append("⌃")
         }
         
-        if self.contains(.shift) {
+        if contains(.shift) {
             result.append("⇧")
         }
         
-        if self.contains(.command) {
+        if contains(.command) {
             result.append("⌘")
         }
         

--- a/MenuTest/Menu/MenuItem.swift
+++ b/MenuTest/Menu/MenuItem.swift
@@ -64,12 +64,12 @@ public struct ShortcutMenuItem: Equatable, MenuItem {
         public let title: String
     }
     
-    public var action: () -> () = {}
+    public var action: () -> Void = {}
     
     public let name: String
     public let shortcut: Shortcut?
     
-    public init(name: String, shortcut: (UIKeyModifierFlags, String)? = nil, action: @escaping () -> ()) {
+    public init(name: String, shortcut: (UIKeyModifierFlags, String)? = nil, action: @escaping () -> Void) {
         self.name = name
         self.action = action
         

--- a/MenuTest/Menu/MenuItemView.swift
+++ b/MenuTest/Menu/MenuItemView.swift
@@ -184,7 +184,8 @@ public class ShortcutMenuItemView: UIView, MenuItemView, MenuThemeable {
         updateHighlightState(false)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.updateHighlightState(true)
+            [weak self] in
+            self?.updateHighlightState(true)
             
             completion()
         }

--- a/MenuTest/Menu/MenuItemView.swift
+++ b/MenuTest/Menu/MenuItemView.swift
@@ -16,13 +16,13 @@ public protocol MenuItemView {
     
     var initialFocusedRect: CGRect? { get }
     
-    var updateLayout: () -> () { get set }
+    var updateLayout: () -> Void { get set }
     
-    func startSelectionAnimation(completion: @escaping ()->())
+    func startSelectionAnimation(completion: @escaping () -> Void)
 }
 
 extension MenuItemView {
-    public func startSelectionAnimation(completion: @escaping ()->()) {}
+    public func startSelectionAnimation(completion: @escaping () -> Void) {}
     
     public var initialFocusedRect: CGRect? { return nil }
 }
@@ -57,7 +57,7 @@ class SeparatorMenuItemView: UIView, MenuItemView, MenuThemeable {
     
     var highlightPosition: CGPoint = .zero
     
-    var updateLayout: () -> () = {}
+    var updateLayout: () -> Void = {}
     
     //MARK: - Themeable
     
@@ -180,7 +180,7 @@ public class ShortcutMenuItemView: UIView, MenuItemView, MenuThemeable {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func startSelectionAnimation(completion: @escaping ()->()) {
+    public func startSelectionAnimation(completion: @escaping () -> Void) {
         updateHighlightState(false)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -200,7 +200,7 @@ public class ShortcutMenuItemView: UIView, MenuItemView, MenuThemeable {
     
     public var highlightPosition: CGPoint = .zero
     
-    public var updateLayout: () -> () = {}
+    public var updateLayout: () -> Void = {}
     
     //MARK: - Themeable Helpers
     

--- a/MenuTest/Menu/MenuView.swift
+++ b/MenuTest/Menu/MenuView.swift
@@ -22,7 +22,7 @@ public class MenuView: UIView, MenuThemeable {
     
     public var title: String {
         didSet {
-            titleLabel.text = title            
+            titleLabel.text = title
             contents?.title = title
         }
     }
@@ -145,7 +145,7 @@ public class MenuView: UIView, MenuThemeable {
         //Highlight whatever we can
         if let contents = self.contents {
             let localPoint = sender.location(in: self)
-            let contentsPoint = self.convert(localPoint, to: contents)
+            let contentsPoint = convert(localPoint, to: contents)
             
             if contents.pointInsideMenuShape(contentsPoint) {
                 contents.highlightedPosition = CGPoint(x: contentsPoint.x, y: localPoint.y)
@@ -175,9 +175,9 @@ public class MenuView: UIView, MenuThemeable {
                     
                     if contents.point(inside: point, with: nil) {
                         contents.selectPosition(point, completion: {
-                            menuItem in
+                            [weak self] menuItem in
                             
-                            self.hideContents(animated: true)
+                            self?.hideContents(animated: true)
                             
                             menuItem.performAction()
                         })
@@ -238,7 +238,7 @@ public class MenuView: UIView, MenuThemeable {
     
     private func hideContents(animated: Bool) {
         let contentsView = contents
-        self.contents = nil
+        contents = nil
         
         longPress?.minimumPressDuration = 0.0
         
@@ -264,10 +264,10 @@ public class MenuView: UIView, MenuThemeable {
     
     private func relayoutContents() {
         if let contents = contents {
-            self.setNeedsLayout()
-            self.layoutIfNeeded()
+            setNeedsLayout()
+            layoutIfNeeded()
             
-            contents.generateMaskAndShadow(alignment: self.contentAlignment)
+            contents.generateMaskAndShadow(alignment: contentAlignment)
         }
     }
     

--- a/MenuTest/Util/UIScrollView+ScrollToRect.swift
+++ b/MenuTest/Util/UIScrollView+ScrollToRect.swift
@@ -15,7 +15,7 @@ import UIKit
 @objc public extension UIScrollView {
     @objc public func scrollOffset(for rect: CGRect) -> CGPoint {
         //Compute the visible area of the scroll view
-        var visibleArea = self.convert(bounds, to: self)
+        var visibleArea = convert(bounds, to: self)
         
         visibleArea.size.height -= (contentInset.top + contentInset.bottom)
         visibleArea.origin.y += contentInset.top

--- a/MenuTest/ViewController.swift
+++ b/MenuTest/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let menu = MenuView(title: "Menu", theme: LightMenuTheme()) { () -> [MenuItem] in
+        let menu = MenuView(title: "Menu", theme: LightMenuTheme()) { [weak self] () -> [MenuItem] in
             return [
                 ShortcutMenuItem(name: "Undo", shortcut: (.command, "Z"), action: {
                     [weak self] in


### PR DESCRIPTION
## Related to Menu
- Fix an ambiguous constraint warning
- Add `[weak self]` to where could be reference cycles (though unlikely to happen)
- Remove unnecessary use of `self` for consistency
- Use `() -> Void` instead of `() -> ()`

## Related to demo app

- Use `[weak self]` when constructing `MenuView` to prevent reference cycle
- Link MapKit.framework to prevent crash on launch
- Extend map view edges to superview instead of safe area