### PR TITLE
Minor improvement in gesture handling and a small bugfix

### DIFF
--- a/MenuTest/Menu/MenuContents.swift
+++ b/MenuTest/Menu/MenuContents.swift
@@ -68,7 +68,10 @@ class MenuContents: UIView {
     
     var isInteractiveDragActive: Bool = false {
         didSet {
-            if isInteractiveDragActive == false {
+            if isInteractiveDragActive {
+                scrollView.panGestureRecognizer.isEnabled = false
+            } else {
+                scrollView.panGestureRecognizer.isEnabled = true
                 edgeScrollTimer?.invalidate()
                 edgeScrollTimer = nil
             }
@@ -84,7 +87,7 @@ class MenuContents: UIView {
     }
     
     private func pointIsInsideTopEdgeScrollingBoundary(_ point: CGPoint) -> Bool {
-        return point.y < scrollView.frame.minY + 40 && isScrollable
+        return point.y < 70 && isScrollable
     }
     
     private func updateHighlightedPosition(_ point: CGPoint) {

--- a/MenuTest/Menu/MenuContents.swift
+++ b/MenuTest/Menu/MenuContents.swift
@@ -84,7 +84,7 @@ class MenuContents: UIView {
     }
     
     private func pointIsInsideTopEdgeScrollingBoundary(_ point: CGPoint) -> Bool {
-        return point.y < scrollView.frame.minY + 40 && isScrollable
+        return point.y < 70 && isScrollable
     }
     
     private func updateHighlightedPosition(_ point: CGPoint) {

--- a/MenuTest/Menu/MenuContents.swift
+++ b/MenuTest/Menu/MenuContents.swift
@@ -68,10 +68,7 @@ class MenuContents: UIView {
     
     var isInteractiveDragActive: Bool = false {
         didSet {
-            if isInteractiveDragActive {
-                scrollView.panGestureRecognizer.isEnabled = false
-            } else {
-                scrollView.panGestureRecognizer.isEnabled = true
+            if isInteractiveDragActive == false {
                 edgeScrollTimer?.invalidate()
                 edgeScrollTimer = nil
             }
@@ -87,7 +84,7 @@ class MenuContents: UIView {
     }
     
     private func pointIsInsideTopEdgeScrollingBoundary(_ point: CGPoint) -> Bool {
-        return point.y < 70 && isScrollable
+        return point.y < scrollView.frame.minY + 40 && isScrollable
     }
     
     private func updateHighlightedPosition(_ point: CGPoint) {

--- a/MenuTest/Menu/MenuView.swift
+++ b/MenuTest/Menu/MenuView.swift
@@ -142,20 +142,18 @@ public class MenuView: UIView, MenuThemeable, UIGestureRecognizerDelegate {
     //MARK: - Gesture Handling
     
     private var gestureStart: Date = .distantPast
-    private var gestureChanged: Date = .distantPast
+    private var startPoint: CGPoint = CGPoint.zero
     
     @objc private func longPressGesture(_ sender: UILongPressGestureRecognizer) {
-        
         switch sender.state {
         case .began:
             if !isShowingContents {
                 showContents()
             }
+            startPoint = sender.location(in: self)
             gestureStart = Date()
         case .changed:
-            gestureChanged = Date()
-            
-            if gestureChanged.timeIntervalSince(gestureStart) > 0.3 {
+            if Date().timeIntervalSince(gestureStart) > 0.3 {
                 contents?.isInteractiveDragActive = true
                 
                 //Highlight whatever we can
@@ -171,7 +169,12 @@ public class MenuView: UIView, MenuThemeable, UIGestureRecognizerDelegate {
         case .cancelled:
             fallthrough
         case .ended:
-            if (gestureChanged.timeIntervalSince(gestureStart) < 0 || contents?.isInteractiveDragActive == true) {
+            let endPoint = sender.location(in: self)
+            let xDist = endPoint.x - startPoint.x
+            let yDist = endPoint.y - startPoint.y
+            let distance = sqrt(xDist * xDist + yDist * yDist)
+            
+            if (distance < 5 || contents?.isInteractiveDragActive == true) {
                 if let contents = contents {
                     let point = convert(sender.location(in: self), to: contents)
                     

--- a/MenuTest/Menu/MenuView.swift
+++ b/MenuTest/Menu/MenuView.swift
@@ -142,18 +142,20 @@ public class MenuView: UIView, MenuThemeable, UIGestureRecognizerDelegate {
     //MARK: - Gesture Handling
     
     private var gestureStart: Date = .distantPast
-    private var startPoint: CGPoint = CGPoint.zero
+    private var gestureChanged: Date = .distantPast
     
     @objc private func longPressGesture(_ sender: UILongPressGestureRecognizer) {
+        
         switch sender.state {
         case .began:
             if !isShowingContents {
                 showContents()
             }
-            startPoint = sender.location(in: self)
             gestureStart = Date()
         case .changed:
-            if Date().timeIntervalSince(gestureStart) > 0.3 {
+            gestureChanged = Date()
+            
+            if gestureChanged.timeIntervalSince(gestureStart) > 0.3 {
                 contents?.isInteractiveDragActive = true
                 
                 //Highlight whatever we can
@@ -169,12 +171,7 @@ public class MenuView: UIView, MenuThemeable, UIGestureRecognizerDelegate {
         case .cancelled:
             fallthrough
         case .ended:
-            let endPoint = sender.location(in: self)
-            let xDist = endPoint.x - startPoint.x
-            let yDist = endPoint.y - startPoint.y
-            let distance = sqrt(xDist * xDist + yDist * yDist)
-            
-            if (distance < 5 || contents?.isInteractiveDragActive == true) {
+            if (gestureChanged.timeIntervalSince(gestureStart) < 0 || contents?.isInteractiveDragActive == true) {
                 if let contents = contents {
                     let point = convert(sender.location(in: self), to: contents)
                     


### PR DESCRIPTION
In the original implementation `longPress` gesture had a delay of 0.07 seconds (to accommodate scrolling). This caused quick taps to not register. My implementation solves this by having another tap gesture which takes care of this edge case and which gets simultaneously detected with `longPress`.

There was another minor bug in the interactive scrolling (in `MenuContents.swift`). It would prevent scrolling back up when the selected element is near the top of the scrollview (during interactive scrolling).